### PR TITLE
Fix missing use_cc_toolchain symbol

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -38,7 +38,7 @@ def bazelisp_repositories():
         git_repository,
         name = "rules_cc",
         remote = "https://github.com/bazelbuild/rules_cc.git",
-        commit = "b1c40e1de81913a3c40e5948f78719c28152486d",
+        commit = "8bb0eb5c5ccd96b91753bb112096bb6993d16d13",
         shallow_since = "1605101351 -0800",
     )
 


### PR DESCRIPTION
Without this fix, I receive this error:

```
ERROR: Traceback (most recent call last):
	File "/private/var/tmp/_bazel_art/c8a5b510bf75c3e5cd5fe54b17c3c02f/external/bazelisp/rules.bzl", line 21, column 67, in <toplevel>
		load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain", "use_cc_toolchain")
Error: file '@rules_cc//cc:find_cc_toolchain.bzl' does not contain symbol 'use_cc_toolchain' (did you mean 'find_cc_toolchain'?)
ERROR: Skipping '//foobar:foobar': error loading package 'foobar': initialization of module 'rules.bzl' failed
WARNING: Target pattern parsing failed.
ERROR: error loading package 'foobar': initialization of module 'rules.bzl' failed
INFO: Elapsed time: 4.436s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded)
    currently loading: foobar
```